### PR TITLE
Fix Production URL

### DIFF
--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  API_URL: 'http://api.pdata.k8s.bio.scai.fraunhofer.de',
+  API_URL: 'https://api.pdata.k8s.bio.scai.fraunhofer.de',
 };


### PR DESCRIPTION
The production was requesting the backend through an unsecured HTTP link. Now requests from HTTPS.