### PR TITLE
refactor: replace deprecated testing class

### DIFF
--- a/frontend/src/app/cohorts/cohorts.component.spec.ts
+++ b/frontend/src/app/cohorts/cohorts.component.spec.ts
@@ -1,5 +1,6 @@
+import { provideHttpClient } from '@angular/common/http';
 import {
-  HttpClientTestingModule,
+  provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
@@ -42,11 +43,8 @@ describe('CohortsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        CohortsComponent,
-        HttpClientTestingModule,
-        NoopAnimationsModule,
-      ],
+      imports: [CohortsComponent, NoopAnimationsModule],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
   }));
 

--- a/frontend/src/app/home/home.component.spec.ts
+++ b/frontend/src/app/home/home.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { HttpClientModule } from '@angular/common/http'; // Import HttpClientModule
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { of } from 'rxjs';
 
@@ -12,11 +13,10 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [
-        HomeComponent,
-        HttpClientModule, // Add HttpClientModule to the imports
-      ],
+      imports: [HomeComponent],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/frontend/src/app/mappings/mappings.component.spec.ts
+++ b/frontend/src/app/mappings/mappings.component.spec.ts
@@ -1,8 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 import {
-  HttpClientTestingModule,
+  provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
@@ -59,8 +60,9 @@ describe('MappingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         ChordDiagramService,
         {
           provide: ActivatedRoute,

--- a/frontend/src/app/plot-longitudinal/plot-longitudinal.component.spec.ts
+++ b/frontend/src/app/plot-longitudinal/plot-longitudinal.component.spec.ts
@@ -1,5 +1,9 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  provideHttpClientTesting,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { PlotLongitudinalComponent } from './plot-longitudinal.component';
@@ -10,8 +14,9 @@ describe('PlotLongitudinalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/frontend/src/app/services/autocomplete.service.spec.ts
+++ b/frontend/src/app/services/autocomplete.service.spec.ts
@@ -1,5 +1,10 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  provideHttpClientTesting,
+  HttpTestingController,
+} from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
 import { AutocompleteService } from './autocomplete.service';
 import { environment } from '../../environments/environment';
 
@@ -10,8 +15,11 @@ describe('AutocompleteService', () => {
   // Setup the testing module and inject the necessary services
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [AutocompleteService],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        AutocompleteService,
+      ],
     });
     service = TestBed.inject(AutocompleteService);
     httpMock = TestBed.inject(HttpTestingController);

--- a/frontend/src/app/services/chord-diagram.service.spec.ts
+++ b/frontend/src/app/services/chord-diagram.service.spec.ts
@@ -1,16 +1,19 @@
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 import {
-  HttpClientTestingModule,
+  provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+
 import * as d3 from 'd3';
+
 import { ChordDiagramService } from './chord-diagram.service';
 import { environment } from '../../environments/environment';
 
 describe('ChordDiagramService', () => {
   let service: ChordDiagramService;
   let httpMock: HttpTestingController;
-  const API_URL = environment.API_URL
+  const API_URL = environment.API_URL;
 
   // Mock data for testing
   const mockData = {
@@ -51,8 +54,11 @@ describe('ChordDiagramService', () => {
   // Set up the testing module and inject the service
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [ChordDiagramService],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ChordDiagramService,
+      ],
     });
     service = TestBed.inject(ChordDiagramService);
     httpMock = TestBed.inject(HttpTestingController);

--- a/frontend/src/app/study-picker/study-picker.component.spec.ts
+++ b/frontend/src/app/study-picker/study-picker.component.spec.ts
@@ -1,8 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 import {
-  HttpClientTestingModule,
+  provideHttpClientTesting,
   HttpTestingController,
 } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -19,10 +20,10 @@ describe('StudyPickerComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         StudyPickerComponent,
-        HttpClientTestingModule,
         ReactiveFormsModule,
         NoopAnimationsModule,
       ],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StudyPickerComponent);


### PR DESCRIPTION
## Pull Request

**Description**  
HttpClientTestingModule is deprecated. Updated the tests accordingly.

**Related Issue**  
closes #127 

**Type of Change**  
- [ ] Bugfix
- [ ] New Feature
- [ ] Documentation
- [x] Refactoring
- [ ] Other (please specify):

**Proposed Changes**  
Instead of `HttpClientTestingModule`: 

```
import { provideHttpClient } from '@angular/common/http';
import {
  provideHttpClientTesting,
  HttpTestingController,
} from '@angular/common/http/testing';
```

include `provideHttpClient()` and `provideHttpClientTesting()` in providers, respectively.

**How to Test**  
`ng test`

**Checklist**  
- [x] My code follows the project's coding style.
- [x] I have tested my changes locally.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes (if applicable).
